### PR TITLE
Fix bad target headers

### DIFF
--- a/src/targets/react-dom.production.min.js
+++ b/src/targets/react-dom.production.min.js
@@ -1,8 +1,8 @@
 import React from 'react';
 /** @license React v@@version@@
- * react-dom.development.js
+ * react-dom.production.min.js
  *
- * Copyright (c) 2013-present, Facebook, Inc.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/targets/react.production.min.js
+++ b/src/targets/react.production.min.js
@@ -1,7 +1,7 @@
 /** @license React v@@version@@
- * react.development.js
+ * react.production.min.js
  *
- * Copyright (c) 2013-present, Facebook, Inc.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
Looks like there was a bad copy-paste for the production file headers. 

While I was there, I also updated the Copyright text to the latest from the official react/react-dom packages.