### PR TITLE
allow users to provide their own react/react-dom versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,11 @@
   "bin": "./src/index.js",
   "dependencies": {
     "acorn": "^5.7.3",
-    "react": "16.6.3",
-    "react-dom": "16.6.3",
     "recast": "^0.15.5"
+  },
+  "peerDependencies": {
+    "react": "*",
+    "react-dom": "*"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
By defining react & react-dom as dependencies, this package will always use those outdated package versions that it marked as explicit dependencies. If you remove them as dependencies, react-ecmascript will pull from whatever versions of react & react-dom that you've installed yourself.